### PR TITLE
[Kerberoasting] requesting RC4 when AES is enabled using pypykatz

### DIFF
--- a/ad/movement/kerberos/kerberoast.md
+++ b/ad/movement/kerberos/kerberoast.md
@@ -41,6 +41,13 @@ Another alternative is the [kerberoast](https://github.com/skelsec/kerberoast) p
 ```bash
 python3 kerberoast spnroast kerberos+pass://"domain"\\"user":"password"@"target" -u "target_user" -r "realm"
 ```
+
+Using [pypykatz](https://github.com/skelsec/pypykatz/wiki/Kerberos-spnroast-command) it is possible to request an RC4 encrypted ST even when AES encryption is enabled. Trying to crack `$krb5tgs$23` takes less time than for `krb5tgs$18`.
+
+```bash
+python3 pypykatz kerberos spnroast 'kerberos+password://DOMAIN\username:Password@IP' -d domain -t target_user
+```
+
 {% endtab %}
 
 {% tab title="Windows" %}


### PR DESCRIPTION
Salut shutdown,

Tout d'abord merci pour avoir mis à disposition `thehacker.recipes`. Je commence tout juste mon premier boulot dans l'infosec et ton travail m’aide beaucoup! 

Concernant ma PR, l'inspiration m'est venue en lisant cette page d'**ired.team**: [Kerberoasting: Requesting RC4 Encrypted TGS when AES is Enabled](https://www.ired.team/offensive-security-experiments/active-directory-kerberos-abuse/kerberoasting-requesting-rc4-encrypted-tgs-when-aes-is-enabled) dans laquelle il est dit qu'on peut utiliser `Rubeus.exe kerberoast /tgtdeleg` pour demander un Service ticket chiffré via RC4 malgré le fait que le chiffrement via AES est activé.

Si on jette un coup d'oeil à [la documentation de `pypykatz`](https://github.com/skelsec/pypykatz/wiki/Kerberos-spnroast-command), on remarque que *"encryption type should be requested - default is RC4 (23)"*. En effet, en demandant un ticket avec `pypykatz`, on parvient à récupérer un ST chiffré via RC4 quand bien même le chiffrement via AES a été mis en place:

![pypykatz_RC4](https://user-images.githubusercontent.com/24477374/167678472-d7170737-e051-4c8e-a874-a45a409bec37.jpeg)

![AES_enabled](https://user-images.githubusercontent.com/24477374/167675109-c1aec121-7429-4478-bb1b-fe722d63b033.png)

En revanche, si on utilise un outil tel que [`kerberoast`](https://github.com/skelsec/kerberoast), on obtiendra un ticket chiffré via AES:

![kerberoast_AES_ticket](https://user-images.githubusercontent.com/24477374/167678066-941be940-277c-40e0-812c-65b329bc8694.jpeg)

Récupérer un ticket chiffré en RC4 (`$krb5tgs$23`) est plus intéressant car nous pourrons potentiellement le cracker plus rapidement qu'un ticket chiffré en AES (`krb5tgs$18`)!  

Merci de m'avoir lu et n’hésite pas à me corriger si je dis des bêtises !
