### PR TITLE
Fix LM & NTLM versions info

### DIFF
--- a/ad/movement/ntlm/README.md
+++ b/ad/movement/ntlm/README.md
@@ -8,7 +8,7 @@
 A common error people do is mix LM, NT, NTLM, Net-NTLM etc. Let's make things clear. There are **hashing formats** used to store user passwords: LM, NT. And there are **authentication protocols** used to authenticate users to remote resources: LM, NTLMv1, and NTLMv2.
 
 * LM hash and NT hash will refer to the hashing formats
-* LM, NTLMv1, and NTLMv2, will refer to the authentication protocols
+* LM, NTLM(v1), and NTLMv2, will refer to the authentication protocols
 * LMv1 and LMv2 are response formats that clients return when responding to NTLM_CHALLENGE NTLMv1 and NTLMv2 messages, respectively.
 
 Yes.. this is confusing, but hey go tell this to Microsoft :triumph:&#x20;

--- a/ad/movement/ntlm/README.md
+++ b/ad/movement/ntlm/README.md
@@ -5,11 +5,11 @@
 ## Theory
 
 {% hint style="danger" %}
-A common error people do is mix LM, NT, NTLM, Net-NTLM etc. Let's make things clear. There are **hashing formats** used to store user passwords: LM, NT. And there are **authentication protocols** used to authenticate users to remote resources: LM (v1 or v2), NTLM (v1 or v2).
+A common error people do is mix LM, NT, NTLM, Net-NTLM etc. Let's make things clear. There are **hashing formats** used to store user passwords: LM, NT. And there are **authentication protocols** used to authenticate users to remote resources: LM, NTLMv1, and NTLMv2.
 
 * LM hash and NT hash will refer to the hashing formats
-* LM(v1), LMv2, NTLM(v1), NTLMv2, will refer to the authentication protocols
-* LM(v1/v2) and NTLM(v1/v2) response will refer to the secret exchanged during an authentication on LM or NTLM.
+* LM, NTLMv1, and NTLMv2, will refer to the authentication protocols
+* LMv1 and LMv2 are response formats that clients return when responding to NTLM_CHALLENGE NTLMv1 and NTLMv2 messages, respectively.
 
 Yes.. this is confusing, but hey go tell this to Microsoft :triumph:&#x20;
 {% endhint %}
@@ -24,7 +24,6 @@ The following table details the secret key used by each authentication protocols
 | Authentication protocol | Algorithm (for the protocol) | Secret key |
 | ----------------------- | ---------------------------- | ---------- |
 | LM                      | DES-ECB                      | LM hash    |
-| LMv2                    | HMAC-MD5                     | NT hash    |
 | NTLM                    | DES-ECB                      | NT hash    |
 | NTLMv2                  | HMAC-MD5                     | NT hash    |
 


### PR DESCRIPTION
Hello Shutdown.

As per [MS-NLMP](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/b38c36ed-2804-4868-a9ff-8dd3182128e4), there is no such protocol as "LMv2". Instead, [LMv2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/8659238f-f5a9-44ad-8ee7-f37d3a172e56), referred to as [LMv2_RESPONSE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/8659238f-f5a9-44ad-8ee7-f37d3a172e56), as opposed to the `LM` protocol, is a response format used by the client when it responds to the server's `NTLMv2` `NTLM_CHALLENGE` message. If `NTLMv1` is used, [LM_RESPONSE](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/e3fee6d1-0d93-4020-84ab-ca4dc5405fc9) is returned instead.

Also, refer to https://curl.se/rfc/ntlm.html#theNtlmv2Response as an additional reference to see that LMv2 is a response returned when NTLMv2 is used.

If I am mistaken, I will be more than happy if you show me references where a protocol such as "LMv2" exists or that "NTLMv1" and "NTLMv2" hashes are referred to as "Net-NTLMv1" and "Net-NTLMv2", as MS-NLMP makes no mention of such terminologies.