### PR TITLE
Fix typo in pyWhisker usage

### DIFF
--- a/ad/movement/kerberos/shadow-credentials.md
+++ b/ad/movement/kerberos/shadow-credentials.md
@@ -34,7 +34,7 @@ If those per-requisites are met, an attacker can
 From UNIX-like systems, the `msDs-KeyCredentialLink` attribute of a user or computer target can be manipulated with the [pyWhisker](https://github.com/ShutdownRepo/pywhisker) tool.
 
 ```bash
-pywhisker.py -d "FQDN_DOMAIN" -u "user1" -p "CERTIFICATE_PASSWORD" --target "TARGET_SAMNAME" --action "list"
+pywhisker.py -d "FQDN_DOMAIN" -u "USER" -p "PASSWORD" --target "TARGET_SAMNAME" --action "list"
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
The `-p ` option is the user password, and not the certificate password (which is `-P`).