### PR TITLE
WebClient searchConnector-ms internet connectivity bypass

### DIFF
--- a/docs/src/ad/movement/mitm-and-coerced-authentications/webclient.md
+++ b/docs/src/ad/movement/mitm-and-coerced-authentications/webclient.md
@@ -157,7 +157,8 @@ With a [searchConnector-ms](https://docs.microsoft.com/en-us/windows/win32/searc
 </searchConnectorDescription>
 ```
 
-In the case where outgoing network traffic is blocked and/or not available this will not work. changing the "simpleLocation" url to a domain controller's NETBIOS name solves the issue as in:
+In cases where outgoing network traffic is blocked and/or not available, this will not work. Changing the "simpleLocation" URL to a domain controller's NETBIOS name solves the issue as shown below:
+
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <searchConnectorDescription xmlns="http://schemas.microsoft.com/windows/2009/searchConnector">


### PR DESCRIPTION
### **User description**
Often times forcing the WebClient service to run on machines that don't have internet connectivity for various reasons such as closed intranet, firewall blocks, NDR etc... will not work.
Changing the url in the searchconnector file to a domain controller's hostname fixes this problem, ALWAYS.


___

### **PR Type**
Documentation


___

### **Description**
- Added WebClient searchConnector-ms workaround for restricted networks

- Provided XML example using domain controller hostname

- Enhanced documentation for offline/firewalled environments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Internet-blocked Environment"] --> B["WebClient Service Fails"]
  B --> C["Use DC Hostname in searchConnector-ms"]
  C --> D["WebClient Service Works"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>webclient.md</strong><dd><code>WebClient offline network workaround documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/ad/movement/mitm-and-coerced-authentications/webclient.md

<ul><li>Added explanation for WebClient issues in restricted networks<br> <li> Provided XML configuration example using domain controller hostname<br> <li> Enhanced troubleshooting guidance for offline environments</ul>


</details>


  </td>
  <td><a href="https://github.com/The-Hacker-Recipes/The-Hacker-Recipes/pull/197/files#diff-71636db9d825364d3ed13fe58894e10ddb19cd428dcac9bc760af33a4a258f2e">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

